### PR TITLE
Fix (skip) for some failing tests in a FreeBSD jail

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -33,8 +33,11 @@ foreach (@if) {
 }
 
 print @loopback ? 'ok ':'not ok ',4,"\n";
+
+my $SKIPPED = ( $^O eq "freebsd" and qx(sysctl security.jail.jailed) =~ m{1} ) ? " # skip FreeBSD jail has no 127.0.0.1" : "";
+
 my @local = grep {$s->if_addr($_) eq '127.0.0.1'} @loopback;
 
-print @local ? 'ok ': 'not ok ',5,"\n";
+print @local ? 'ok ': 'not ok ',5,"$SKIPPED\n";
 
 

--- a/t/simple.t
+++ b/t/simple.t
@@ -27,7 +27,7 @@ ok($loopback,"loopback device");
 
 SKIP: {
   my $index = $loopback->index;
-  skip ('index not implemented on this platform',3) unless defined $index;
+  skip ('index not implemented on this platform',5) unless defined $index;
   ok($loopback->address eq '127.0.0.1','loopback address');
   ok($loopback->netmask eq '255.0.0.0','loopback netmask');
 

--- a/t/simple.t
+++ b/t/simple.t
@@ -22,13 +22,14 @@ foreach (@if) {
 }
 
 ok($loopback,"loopback device");
-ok($loopback->address eq '127.0.0.1','loopback address');
-ok($loopback->netmask eq '255.0.0.0','loopback netmask');
+
+#  skip ('FreeBSD jail has no 127.0.0.1') if ( $^O eq "freebsd" and qx(sysctl security.jail.jailed) =~ m{1} );
 
 SKIP: {
   my $index = $loopback->index;
   skip ('index not implemented on this platform',3) unless defined $index;
-  skip ('FreeBSD jail has no 127.0.0.1') if ( $^O eq "freebsd" and qx(sysctl security.jail.jailed) =~ m{1} );
+  ok($loopback->address eq '127.0.0.1','loopback address');
+  ok($loopback->netmask eq '255.0.0.0','loopback netmask');
 
   ok(defined $index,'loopback index');
 

--- a/t/simple.t
+++ b/t/simple.t
@@ -28,6 +28,7 @@ ok($loopback->netmask eq '255.0.0.0','loopback netmask');
 SKIP: {
   my $index = $loopback->index;
   skip ('index not implemented on this platform',3) unless defined $index;
+  skip ('FreeBSD jail has no 127.0.0.1') if ( $^O eq "freebsd" and qx(sysctl security.jail.jailed) =~ m{1} );
 
   ok(defined $index,'loopback index');
 


### PR DESCRIPTION
In FreeBSD Jails, the loopback interface usually has no IP address, but when using 127.0.0.1 then the local ip address is connected.

Some tests fail:

```
Running Build test
t/basic.t ... Failed 1/5 subtests 
t/simple.t .. 1/11 
#   Failed test 'loopback address'
#   at t/simple.t line 25.

#   Failed test 'loopback netmask'
#   at t/simple.t line 26.
# Looks like you failed 2 tests of 11.
t/simple.t .. Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/11 subtests 
        (less 3 skipped subtests: 6 okay)

Test Summary Report
-------------------
t/basic.t (Wstat: 0 Tests: 5 Failed: 1)
  Failed test:  5
t/simple.t (Wstat: 512 Tests: 11 Failed: 2)
  Failed tests:  7-8
  Non-zero exit status: 2
Files=2, Tests=16,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.09 cusr  0.04 csys =  0.16 CPU)
Result: FAIL
Failed 2/2 test programs. 3/16 subtests failed.
  LDS/IO-Interface-1.09.tar.gz
  ./Build test -- NOT OK
```

I fixed this by skipping the test in simple.t when the OS is FreeBSD and the test running inside a jail; in simple.t i fixed this by moving the failing test into the existing SKIP block.
