### PR TITLE
Fix build flags after switching to Module::Build

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -2,6 +2,51 @@
 
 use strict;
 use Module::Build;
+use Config;
+
+sub compiler_flags() {
+    my @flags = ();
+    my %cfg = (
+        'freebsd' => '-D__USE_BSD',
+        'netbsd'  => '-D__USE_BSD',
+        'openbsd' => '-D__USE_BSD',
+    );
+
+    print "Checking for BSD-like operating system...";
+    if (exists $cfg{$^O}) {
+        push @flags, $cfg{$^O};
+        print " Okay, present.\n";
+    } else {
+       print " Nope, not present.\n";
+    }
+
+    print "Checking for SIOCGIFCONF...";
+    if (!-r "/usr/include/sys/sockio.h") {
+        print " Nope, will not use it.\n";
+    } else {
+        push @flags, '-DSIOCGIFCONF';
+        print " Okay, I will use it.\n";
+    }
+
+    print "Checking for getifaddrs()...";
+    eval { require 'ifaddrs.ph' };
+    if ($@ && !-r "/usr/include/ifaddrs.h") {
+        print " Nope, will not use it.\n";
+    } else {
+        push @flags, '-DUSE_GETIFADDRS';
+        print " Okay, I will use it.\n";
+    }
+
+    print "Checking for sockaddr_dl...";
+    if (!-r "/usr/include/net/if_dl.h") {
+        print " Nope, will not use it.\n";
+    } else {
+        push @flags, '-DHAVE_SOCKADDR_DL_STRUCT';
+        print " Okay, I will use it.\n";
+    }
+
+    return \@flags;
+}
 
 my $build = Module::Build->new(
     module_name        => 'IO::Interface',
@@ -9,13 +54,20 @@ my $build = Module::Build->new(
     dist_author        => 'Lincoln Stein <lincoln.stein@gmail.com>',
     dist_abstract      => 'Access and modify network interface card configuration',
     license            => 'perl',
-    build_requires => {
-	'ExtUtils::CBuilder' => 0,
+    dynamic_config     => 1,
+    extra_compiler_flags => compiler_flags(),
+    build_requires     => {
+	'Config'              => 0,
+        'ExtUtils::CBuilder'  => 0,
     },
-    requires     => {
-	'perl'                => '5.005',
+    requires           => {
+        'perl'                => '5.005',
     },
-    );
+    'resources'        => {
+        'homepage'            => 'https://metacpan.org/dist/IO-Interface',
+        'repository'          => 'https://github.com/lstein/LibIO-Interface-Perl/',
+    },
+);
 
 $build->create_build_script();
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Perl extension IO::Interface.
+
+1.10	Sun Dec 10 15:54:57 GMT 2017
+        -Fix build flags after switching to Module::Build
+
 1.09    Tue Dec  9 11:22:56 EST 2014
 	-Converted to use Module::Build
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -5,8 +5,6 @@ lib/IO/Interface.xs
 lib/IO/Interface/Simple.pm
 LICENSE
 MANIFEST
-META.json
-META.yml			Module meta-data (added by MakeMaker)
 README.md
 t/basic.t
 t/simple.t

--- a/lib/IO/Interface.pm
+++ b/lib/IO/Interface.pm
@@ -27,7 +27,7 @@ my @flags     = qw(IFF_ALLMULTI    IFF_AUTOMEDIA  IFF_BROADCAST
 @EXPORT = qw( );
 
 @ISA = qw(Exporter DynaLoader);
-$VERSION = '1.09';
+$VERSION = '1.10';
 
 sub AUTOLOAD {
     # This AUTOLOAD is used to 'autoload' constants from the constant()


### PR DESCRIPTION
Should fix issues #1 and #2. It mimics what was in Makefile.PL before switch to Build.PL.